### PR TITLE
Add title field to github issues

### DIFF
--- a/datasources/github.js
+++ b/datasources/github.js
@@ -106,6 +106,7 @@ class GithubApi {
                 number
                 body
                 url
+                title
                 state
                 repository {
                   name


### PR DESCRIPTION
Title field was missing when querying github issues. This has been added to the query. 