### PR TITLE
Add the ability to choose which datasource to select

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ const typeDefs = gql`
   
 `;
 
-const resolveMultipleSearches = (dataSources, searchString, dataSourcesToSearch = []) => {
+const resolveMultipleSearches = (dataSources, searchString, dataSourcesToSearch = ['rocketchat', 'documize', 'github']) => {
   const config = { ...baseConfig, ...userConfig };
   console.log(dataSourcesToSearch, dataSources);
   return DATA_SOURCE_NAMES.filter((source) => dataSourcesToSearch.includes(source)).map((source) => {


### PR DESCRIPTION
This will allow clients to selectively query the gateway using the 

`dataSources: [...]` graphql query argument