### PR TITLE
Catch errors from federators and return empty array

### DIFF
--- a/datasources/docugate.js
+++ b/datasources/docugate.js
@@ -52,7 +52,7 @@ class DocumizeApi extends GraphQLDataSource {
       return response.data.search.map(DocumizeApi.documizeResultReducer);
     } catch (error) {
       console.error(error);
-      throw error;
+      return [];
     }
   }
 }

--- a/datasources/rocket.gate.js
+++ b/datasources/rocket.gate.js
@@ -56,7 +56,7 @@ class RocketGateApi extends GraphQLDataSource {
       return response.data.search.map(RocketGateApi.rocketChatResultReducer);
     } catch (error) {
       console.error(error);
-      throw error;
+      return [];
     }
   }
 }

--- a/openshift/dc.yaml
+++ b/openshift/dc.yaml
@@ -39,13 +39,13 @@ objects:
         - image: ${NAME}:${VERSION}
           name: searchgate
           ports:
-          - containerPort: 4000
+          - containerPort: 4001
             protocol: TCP
           readinessProbe:
             failureThreshold: 3
             httpGet:
               path: /.well-known/apollo/server-health
-              port: 4000
+              port: 4001
               scheme: HTTP
             initialDelaySeconds: 4
             periodSeconds: 10

--- a/openshift/dc.yaml
+++ b/openshift/dc.yaml
@@ -41,6 +41,16 @@ objects:
           ports:
           - containerPort: 4000
             protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /.well-known/apollo/server-health
+              port: 4000
+              scheme: HTTP
+            initialDelaySeconds: 4
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 4
           resources:
             requests:
               cpu: '100m'


### PR DESCRIPTION
To fix an issue thtat would cause search gate to delegate federator errors to client